### PR TITLE
Setup to build on Netlify

### DIFF
--- a/core.spec.md
+++ b/core.spec.md
@@ -7,8 +7,8 @@
   <tr><td>Status</td><td>Release</td>
   <tr><td>Version</td><td>0.1</td>
 </table>
-<link rel=stylesheet href=/apollo-light.css>
-<script type=module async defer src=/inject-logo.js></script>
+<link rel=stylesheet href=https://specs.apollo.dev/apollo-light.css>
+<script type=module async defer src=https://specs.apollo.dev/inject-logo.js></script>
 ```
 
 [GraphQL](https://spec.graphql.org/) provides directives as a means of attaching user-defined metadata to a GraphQL document. Directives are highly flexible, and can be used to suggest behavior and define features of a graph which are not otherwise evident in the schema.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+# Netlify Admin: https://app.netlify.com/sites/apollo-specs-core/
+# Docs: https://docs.netlify.com/configure-builds/file-based-configuration/
+
+[build]
+  command = "npm run build"
+  publish = ".dist/"


### PR DESCRIPTION
> This is part of a multi-step migration, outlined in:
>
> * https://github.com/apollo-specs/apollo-specs.github.io/issues/6
>
> This shouldn't merge until the right point in that flow (though it's very early on, indeed, and it won't break anything if it merges), but perhaps review that in conjunction with this.

This sets up the Netlify configuration for this spec site, and enables us to migrate from GitHub pages to the standard way we deploy website properties across Apollo: Netlify.

The site has been added in Netlify already at:
  https://app.netlify.com/sites/apollo-specs-core/

This also changes the CSS and logo-rendering paths to reference the specs site using its FQDN as a full URL to enable the site to work anywhere it is mounted, including on localhost and on Netlify previews.

In the future, perhaps we can have this bundled into the spec site itself so the site can stand on its own in the same way that our docs do, and not require external artifacts (and have our deploys be more hermetically sealed / perma-durable on Netlify).