### PR TITLE
Remove core-schema link/header ?

### DIFF
--- a/core.spec.md
+++ b/core.spec.md
@@ -24,13 +24,6 @@ The second is unfortunate: GraphQL schemas are generally intended to be self-des
 
 Introducing **core schemas**.
 
-<div class=hbox>
-  <a class=core>
-    <div class=ring></div>
-    <div class=nucleus>core schema</div>
-  </a>
-</div>
-
 A basic core schema:
 
 :::[example](basic.graphql) -- A basic core schema


### PR DESCRIPTION
The `core schema` renders as a link in my setup (chrome) although I cannot click it (see below). Maybe there's a better fix, I'm not sure what the initial intent was, looks like this was designed to do something else but I can't figure out what. 
Feel free to discard this PR if I'm missing something.

![Screenshot 2021-07-02 at 16 22 21](https://user-images.githubusercontent.com/3974977/124288989-16211480-db52-11eb-8951-8681675489a4.png)
